### PR TITLE
Add parsing of TCP headers.

### DIFF
--- a/src/ethernet.rs
+++ b/src/ethernet.rs
@@ -9,13 +9,13 @@ pub enum EtherType {
     IPv4,
     ARP,
     IPv6,
-    VLAN
+    VLAN,
 }
 #[derive(Debug, PartialEq, Eq)]
 pub struct EthernetFrame {
-    pub source_mac : MacAddress,
-    pub dest_mac   : MacAddress,
-    pub ethertype  : EtherType
+    pub source_mac: MacAddress,
+    pub dest_mac: MacAddress,
+    pub ethertype: EtherType,
 }
 
 fn to_ethertype(i: u16) -> Option<EtherType> {
@@ -24,18 +24,20 @@ fn to_ethertype(i: u16) -> Option<EtherType> {
         0x0806 => Some(EtherType::ARP),
         0x8100 => Some(EtherType::VLAN),
         0x86DD => Some(EtherType::IPv6),
-        _ => None
+        _ => None,
     }
 }
 
 fn to_mac_address(i: &[u8]) -> MacAddress {
-    MacAddress(array_ref![i,0,6].clone())
+    MacAddress(array_ref![i, 0, 6].clone())
 }
 
 named!(mac_address<&[u8], MacAddress>, map!(take!(6), to_mac_address));
 named!(ethertype<&[u8], EtherType>, map_opt!(u16!(true), to_ethertype));
 named!(ethernet_frame<&[u8], EthernetFrame>, chain!(
-    dest_mac: mac_address ~ src_mac: mac_address ~ et: ethertype,
+    dest_mac: mac_address ~
+    src_mac: mac_address ~
+    et: ethertype,
     || EthernetFrame{source_mac: src_mac, dest_mac: dest_mac, ethertype: et}
 ));
 
@@ -47,7 +49,7 @@ pub fn parse_ethernet_frame(i: &[u8]) -> IResult<&[u8], EthernetFrame> {
 mod tests {
     use super::{mac_address, ethertype, ethernet_frame, MacAddress, EtherType, EthernetFrame};
     use nom::IResult;
-    const EMPTY_SLICE : &'static [u8] = &[];
+    const EMPTY_SLICE: &'static [u8] = &[];
     #[test]
     fn mac_address_works() {
         let bytes = [0x9c, 0x5c, 0x8e, 0x90, 0xca, 0xfc];
@@ -71,14 +73,14 @@ mod tests {
 
     #[test]
     fn ethernet_frame_works() {
-        let bytes =
-            [0x00, 0x23, 0x54, 0x07, 0x93, 0x6c, // dest MAC
-             0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b, // src MAC
-             0x08, 0x00]; // Ethertype
+        let bytes = [0x00, 0x23, 0x54, 0x07, 0x93, 0x6c, /* dest MAC */
+                     0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b, /* src MAC */ 
+                     0x08, 0x00 // Ethertype
+                    ];
         let expectation = EthernetFrame {
             source_mac: MacAddress([0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b]),
             dest_mac: MacAddress([0x00, 0x23, 0x54, 0x07, 0x93, 0x6c]),
-            ethertype: EtherType::IPv4
+            ethertype: EtherType::IPv4,
         };
         assert_eq!(ethernet_frame(&bytes), IResult::Done(EMPTY_SLICE, expectation));
     }

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -8,22 +8,22 @@ pub struct IPv4Address(pub [u8; 4]);
 pub enum IPv4Protocol {
     ICMP,
     TCP,
-    UDP
+    UDP,
 }
 #[derive(Debug, PartialEq, Eq)]
 pub struct IPv4Header {
-    pub version : u8,
-    pub ihl : u8,
-    pub tos : u8,
-    pub length : u16,
-    pub id : u16,
-    pub flags : u8,
-    pub fragment_offset : u16,
-    pub ttl : u8,
-    pub protocol : IPv4Protocol,
-    pub chksum : u16,
-    pub source_addr : IPv4Address,
-    pub dest_addr : IPv4Address
+    pub version: u8,
+    pub ihl: u8,
+    pub tos: u8,
+    pub length: u16,
+    pub id: u16,
+    pub flags: u8,
+    pub fragment_offset: u16,
+    pub ttl: u8,
+    pub protocol: IPv4Protocol,
+    pub chksum: u16,
+    pub source_addr: IPv4Address,
+    pub dest_addr: IPv4Address,
 }
 
 fn to_ipv4_protocol(i: u8) -> Option<IPv4Protocol> {
@@ -31,18 +31,19 @@ fn to_ipv4_protocol(i: u8) -> Option<IPv4Protocol> {
         1 => Some(IPv4Protocol::ICMP),
         6 => Some(IPv4Protocol::TCP),
         17 => Some(IPv4Protocol::UDP),
-        _ => None
+        _ => None,
     }
 }
 
 fn to_ipv4_address(i: &[u8]) -> IPv4Address {
-    IPv4Address(array_ref![i,0,4].clone())
+    IPv4Address(array_ref![i, 0, 4].clone())
 }
 
 named!(two_nibbles<&[u8], (u8, u8)>, bits!(pair!(take_bits!(u8, 4), take_bits!(u8, 4))));
 named!(flag_frag_offset<&[u8], (u8, u16)>, bits!(pair!(take_bits!(u8, 3), take_bits!(u16, 13))));
 named!(protocol<&[u8], IPv4Protocol>, map_opt!(be_u8, to_ipv4_protocol));
 named!(address<&[u8], IPv4Address>, map!(take!(4), to_ipv4_address));
+
 named!(ipparse<&[u8], IPv4Header>,
        chain!(verihl : two_nibbles ~
               tos : be_u8 ~
@@ -77,7 +78,7 @@ pub fn parse_ipv4_header(i: &[u8]) -> IResult<&[u8], IPv4Header> {
 mod tests {
     use super::{protocol, IPv4Protocol, ipparse, IPv4Header, IPv4Address};
     use nom::IResult;
-    const EMPTY_SLICE : &'static [u8] = &[];
+    const EMPTY_SLICE: &'static [u8] = &[];
     macro_rules! mk_protocol_test {
         ($func_name:ident, $bytes:expr, $correct_proto:expr) => (
             #[test]
@@ -94,18 +95,17 @@ mod tests {
 
     #[test]
     fn ipparse_gets_packet_correct() {
-        let bytes =
-            [0x45, // IP version and length = 20
-             0x00, // Differentiated services field
-             0x05, 0xdc, // Total length
-             0x1a, 0xe6, // Identification
-             0x20, 0x00, // flags and fragment offset
-             0x40, // TTL
-             0x01, // protocol
-             0x22, 0xed, // checksum
-             0x0a, 0x0a, 0x01, 0x87, // source IP
-             0x0a, 0x0a, 0x01, 0xb4 // destination IP
-            ];
+        let bytes = [0x45, /* IP version and length = 20 */
+                     0x00, /* Differentiated services field */ 
+                     0x05, 0xdc, /* Total length */ 
+                     0x1a, 0xe6, /* Identification */
+                     0x20, 0x00, /* flags and fragment offset */
+                     0x40, /* TTL */
+                     0x01, /* protocol */
+                     0x22, 0xed, /* checksum */
+                     0x0a, 0x0a, 0x01, 0x87, /* source IP */
+                     0x0a, 0x0a, 0x01, 0xb4, /* destination IP */];
+
         let expectation = IPv4Header {
             version: 4,
             ihl: 20,
@@ -118,7 +118,7 @@ mod tests {
             protocol: IPv4Protocol::ICMP,
             chksum: 0x22ed,
             source_addr: IPv4Address([10, 10, 1, 135]),
-            dest_addr: IPv4Address([10, 10, 1, 180])
+            dest_addr: IPv4Address([10, 10, 1, 180]),
         };
         assert_eq!(ipparse(&bytes), IResult::Done(EMPTY_SLICE, expectation));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ extern crate arrayref;
 
 pub mod ethernet;
 pub mod ipv4;
+pub mod tcp;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,0 +1,148 @@
+//! Handles parsing of TCP headers
+
+use nom::IResult;
+
+// TCP Header Format
+//
+//
+//    0                   1                   2                   3
+//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |          Source Port          |       Destination Port        |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |                        Sequence Number                        |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |                    Acknowledgment Number                      |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |  Data |           |U|A|P|R|S|F|                               |
+//   | Offset| Reserved  |R|C|S|S|Y|I|            Window             |
+//   |       |           |G|K|H|T|N|N|                               |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |           Checksum            |         Urgent Pointer        |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |                    Options                    |    Padding    |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |                             data                              |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+// TCP Flags:
+//    URG:  Urgent Pointer field significant
+//    ACK:  Acknowledgment field significant
+//    PSH:  Push Function
+//    RST:  Reset the connection
+//    SYN:  Synchronize sequence numbers
+//    FIN:  No more data from sender
+
+
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct TcpHeader<'a> {
+    pub source_port: u16,
+    pub dest_port: u16,
+    pub sequence_no: u32,
+    pub ack_no: u32,
+    pub data_offset: u8,
+    pub reserved: u8,
+    pub flag_urg: bool,
+    pub flag_ack: bool,
+    pub flag_psh: bool,
+    pub flag_rst: bool,
+    pub flag_syn: bool,
+    pub flag_fin: bool,
+    pub window: u16,
+    pub checksum: u16,
+    pub urgent_pointer: u16,
+    pub options: Option<&'a[u8]>,
+}
+named!(dataof_res_flags<&[u8], (u8, u8, u8)>,
+    bits!(tuple!(
+        take_bits!(u8, 4),
+        take_bits!(u8, 6),
+        take_bits!(u8, 6))));
+
+named!(tcp_parse<&[u8], TcpHeader>,
+       dbg_dmp!(chain!(src: u16!(true) ~
+              dst: u16!(true) ~
+              seq: u32!(true) ~
+              ack: u32!(true) ~
+              dataof_res_flags : dataof_res_flags ~
+              window : u16!(true) ~
+              checksum : u16!(true) ~
+              urgent_ptr : u16!(true),
+              || {
+                  TcpHeader {
+                  source_port: src,
+                  dest_port : dst,
+                  sequence_no : seq,
+                  ack_no : ack,
+                  data_offset : dataof_res_flags.0 * 4,
+                  reserved : dataof_res_flags.1,
+                  flag_urg : dataof_res_flags.2 & 0b100000 == 0b100000,
+                  flag_ack : dataof_res_flags.2 & 0b010000 == 0b010000,
+                  flag_psh : dataof_res_flags.2 & 0b001000 == 0b001000,
+                  flag_rst : dataof_res_flags.2 & 0b000100 == 0b000100,
+                  flag_syn : dataof_res_flags.2 & 0b000010 == 0b000010,
+                  flag_fin : dataof_res_flags.2 & 0b000001 == 0b000001,
+                  window : window,
+                  checksum : checksum,
+                  urgent_pointer : urgent_ptr,
+                  options : None
+              }})));
+
+pub fn parse_tcp_header(i: &[u8]) -> IResult<&[u8], TcpHeader> {
+    match tcp_parse(i) {
+        IResult::Done(left, mut tcp_header) => {
+            let options_length = (tcp_header.data_offset - 20) as usize;
+            // TODO: For now TcpHeader options are not parsed and contains the raw bytes.
+            if options_length > 0 {
+                tcp_header.options = Some(&left[..options_length]);
+                IResult::Done(&left[options_length..], tcp_header)
+            } else {
+                IResult::Done(left, tcp_header)
+            }
+        }
+
+        e => e,
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use nom::IResult;
+
+    const EMPTY_SLICE: &'static [u8] = &[];
+
+    #[test]
+    fn test_tcp_parse() {
+        let bytes = [0xc2, 0x1f, /* Source port */ 
+                     0x00, 0x50, /* Dest port */
+                     0x0f, 0xd8, 0x7f, 0x4c, /* Seq no */
+                     0xeb, 0x2f, 0x05, 0xc8, /* Ack no */
+                     0x50, 0x18, 0x01, 0x00, /* Window */
+                     0x7c, 0x29, /* Checksum */
+                     0x00, 0x00 /* Urgent pointer */];
+
+        let expectation = TcpHeader {
+            source_port: 49695,
+            dest_port: 80,
+            sequence_no: 0x0fd87f4c,
+            ack_no: 0xeb2f05c8,
+            data_offset: 20,
+            reserved: 0,
+            flag_urg: false,
+            flag_ack: true,
+            flag_psh: true,
+            flag_rst: false,
+            flag_syn: false,
+            flag_fin: false,
+            window: 256,
+            checksum: 0x7c29,
+            urgent_pointer: 0,
+            options: None,
+        };
+
+        assert_eq!(parse_tcp_header(&bytes), IResult::Done(EMPTY_SLICE, expectation));
+    }
+}

--- a/tests/tcp_packet.rs
+++ b/tests/tcp_packet.rs
@@ -1,0 +1,33 @@
+#[macro_use]
+extern crate nom;
+extern crate pktparse;
+
+mod tests {
+    use nom::IResult::Done;
+    use pktparse::{ethernet, ipv4, tcp};
+    use pktparse::ipv4::{IPv4Header, IPv4Address, IPv4Protocol};
+    use pktparse::ethernet::{EthernetFrame, MacAddress, EtherType};
+
+    #[test]
+    fn parse_tcp_packet() {
+    
+        let bytes = [
+           0x45, 0x00, 0x00, 0x38, 0x76, 0xf4, 0x40, 0x00, 0x40, 0x06, 0x80, 0xd9, 0xc0, 0xa8, 0x00, 
+           0x6c, 0xd0, 0x61, 0xb1, 0x7c, 0xb0, 0xc2, 0x00, 0x50, 0xb0, 0xee, 0x32, 0xa6, 0x04, 0x39, 
+           0xae, 0xe6, 0x50, 0x18, 0x00, 0xe5, 0x76, 0x92, 0x00, 0x00, 0x47, 0x45, 0x54, 0x20, 0x2f, 
+           0x69, 0x6e, 0x64, 0x65, 0x78, 0x2e, 0x68, 0x74, 0x6d, 0x6c, 0x0a];
+        
+        if let Done(remaining, ip_hdr) = ipv4::parse_ipv4_header(&bytes) {
+            if let Done(remaining, tcp_hdr) = tcp::parse_tcp_header(remaining) {
+                assert_eq!(tcp_hdr.source_port, 45250);
+                assert_eq!(tcp_hdr.dest_port, 80);
+                assert_eq!(&remaining[..], b"GET /index.html\x0a");
+            }
+            else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+}


### PR DESCRIPTION
Hi @moosingin3space,

I started adding parsing for TCP packets as a learning project with nom. This pull request is to know if you would be interested in merging this in your project. I still need to properly parse the options field in the TCP header but that shouldn't be too long to write. Also my current commit modifies the other files because I used cargo-fmt, I can put those changes in a separate commit if you would prefer that.

Thanks,

ekse 
